### PR TITLE
Reject Windows-incompatible filenames

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-  
+
     - name: "Validate PackageInfo.g"
       shell: bash
       run: |
@@ -36,7 +36,7 @@ runs:
             exit 1
         fi
         mv package-info.json $ASSETS
-        
+
     - name: "Read data from package-info.json"
       shell: bash
       working-directory: ${{ env.ASSETS }}
@@ -107,11 +107,11 @@ runs:
       run: |
         mkdir -p "$RUNNER_TEMP/$BASENAME"
         cp -r * "$RUNNER_TEMP/$BASENAME"
-        
+
     - name: "Cleanup before making archives"
       shell: bash
       working-directory: ${{ runner.temp }}/${{ env.BASENAME }}
-      run: | 
+      run: |
          echo "::group:: Cleanup git and github related files"
          rm -rvf .git* .hg* .cvs* .circleci
          echo "::group:: Cleanup codecov, travis, azure-pipelines"


### PR DESCRIPTION
Closes #21.

This will specifically throw an error when:

- A file or directory has a reserved name (aux, con, etc)
- A file or directory contains a reserved character (`:`, `"`, `\`, etc)
- A file or directory has a name ending in a space or a period
- Two or more files or directories have the same name up to case

This doesn't catch *every* incompatible name, but it should at least catch any such name that a package author may **unintentionally** create...