### PR TITLE
Add a body-text input, for describing the GitHub release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "Set to true to allow this action to overwrite an existing release, and to make a release with an incorrect date"
     required: false
     default: "false"
+  body-text:
+    description: "Body text for the new GitHub release that will appear on the package's GitHub Releases page"
+    required: false
+    default: "Release of ${{ github.event.repository.name }}"
 
 runs:
   using: "composite"
@@ -167,8 +171,8 @@ runs:
       uses: softprops/action-gh-release@v2
       if: ${{ inputs.dry-run == 'false' }}
       with:
-        body: "Release for ${{ env.PKGNAME }}"
         name: "${{ env.PKGNAME }} ${{ env.VERSION }}"
+        body: "${{ inputs.body-text }}"
         fail_on_unmatched_files: true
         tag_name: "${{ env.TAG }}"
         files: ${{ env.ASSETS }}/*


### PR DESCRIPTION
I've tested this quite a bit on my fork of the Digraphs package and it seems to work for my purposes (see https://github.com/digraphs/Digraphs/pull/803).

I've changed the default text `Release for <PKG>` to `Release of <PKG>`, because that seems more grammatically correct to me.

Closes #17.