### PR TITLE
Fix body text with backticks in dry runs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -250,7 +250,7 @@ runs:
     - name: "Copy body-text"
       if: ${{ inputs.dry-run == 'true' }}
       shell: bash
-      run: echo "${{ inputs.body-text }}" > $RUNNER_TEMP/Release_text_for_${PKGNAME}_${VERSION}${{ inputs._affix }}.md
+      run: echo '${{ inputs.body-text }}' > $RUNNER_TEMP/Release_text_for_${PKGNAME}_${VERSION}${{ inputs._affix }}.md
 
     - name: "Upload the release assets"
       uses: actions/upload-artifact@v7


### PR DESCRIPTION
Due to backticks being special in bash (acting almost the same as `$( ... )`), it's actually not that straightforward to get these into a `.md` file properly. Currently, any text between backticks is evaluated and replaced by its output (which is in most cases empty because the evaluated text just causes an error).

This PR fixes that erroneous behaviour.

Note: this problem only happens for dry runs. Body text for actual releases is not impacted.