### PR TITLE
Use HEREDOC when writing body text to file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -250,7 +250,10 @@ runs:
     - name: "Copy body-text"
       if: ${{ inputs.dry-run == 'true' }}
       shell: bash
-      run: echo '${{ inputs.body-text }}' > $RUNNER_TEMP/Release_text_for_${PKGNAME}_${VERSION}${{ inputs._affix }}.md
+      run: |
+        cat > "$RUNNER_TEMP/Release_text_for_${PKGNAME}_${VERSION}${{ inputs._affix }}.md" <<'RELEASETEXTGOESHERE'
+        ${{ inputs.body-text }}
+        RELEASETEXTGOESHERE
 
     - name: "Upload the release assets"
       uses: actions/upload-artifact@v7


### PR DESCRIPTION
The previous fix #61 fixed backticks in the body text breaking the script. But now single quotes can break it, as I discovered [here](https://github.com/stertooy/SmallClassNr/actions/runs/24001665355/job/69998614924#step:8:520).

I think (hope) that using heredocs instead will be the safer option... provided nobody decides to put `RELEASETEXTGOESHERE` in the body text.