### PR TITLE
Update `action-gh-release` to `v3`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -237,7 +237,7 @@ runs:
         done
 
     - name: "Make GitHub release"
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       if: ${{ inputs.dry-run == 'false' }}
       with:
         name: "${{ env.PKGNAME }} ${{ env.VERSION }}"


### PR DESCRIPTION
To get rid of the warning about Node.js 20 deprecation...